### PR TITLE
Add credentials flexibility.

### DIFF
--- a/df2gspread/df2gspread.py
+++ b/df2gspread/df2gspread.py
@@ -22,12 +22,12 @@ except NameError:  # Python 3
 
 
 def upload(df, gfile="/New Spreadsheet", wks_name=None, chunk_size=1000,
-           col_names=True, row_names=True, clean=True):
+           col_names=True, row_names=True, clean=True, credentials=True):
     '''
     FIXME DOCs
     '''
     # access credentials
-    credentials = get_credentials()
+    credentials = get_credentials(credentials)
     # auth for gspread
     gc = gspread.authorize(credentials)
 

--- a/df2gspread/gspread2df.py
+++ b/df2gspread/gspread2df.py
@@ -26,12 +26,13 @@ SCOPES = ('https://www.googleapis.com/auth/drive.metadata.readonly '
 
 
 def download(gfile="/New Spreadsheet", wks_name=None, col_names=False,
-             row_names=False):
+             row_names=False, credentials=None):
     '''
     FIXME DOCs
     '''
+
     # access credentials
-    credentials = get_credentials()
+    credentials = get_credentials(credentials)
     # auth for gspread
     gc = gspread.authorize(credentials)
 

--- a/df2gspread/utils.py
+++ b/df2gspread/utils.py
@@ -130,7 +130,9 @@ def create_service_credentials(private_key_file=None, client_email=None,
     if client_email is None:
         with open(client_secret_file) as client_file:
             client_data = json.load(client_file)
+
             if 'installed' in client_data:
+
                 # handle regular json format where key is separate
                 client_email = client_data['installed']['client_id']
                 if private_key is None:
@@ -138,8 +140,12 @@ def create_service_credentials(private_key_file=None, client_email=None,
                                        with the regular json file. Try creating a new \
                                        public/private key pair and downloading as json.')
             else:
+                # handle newer case where json file has everything in it
                 client_email = client_data['client_email']
                 private_key = client_data['private_key']
+
+    if client_email is None or private_key is None:
+        raise RuntimeError('Client email and/or private key not provided by inputs.')
 
     credentials = client.SignedJwtAssertionCredentials(client_email, private_key, SCOPES)
 

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ __irequires__ = [
     'gspread==0.2.5',
     'oauth2client>=1.4.12',
     'pandas',
+    'pycrypto'
 ]
 __xrequires__ = {
     'tests': [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,41 @@
+
+import pytest
+
+from df2gspread.utils import (get_credentials,
+                              create_service_credentials)
+
+
+@pytest.fixture
+def service_credentials():
+
+    sc = dict(key_file='~/.df2gspread_secrets.p12',
+              client_file='~/.gdrive_service_private')
+
+    return sc
+
+
+@pytest.fixture
+def user_credentials_not_available():
+    try:
+        _ = get_credentials()
+        should_fail = False
+    except IOError:
+        should_fail = True
+
+    return should_fail
+
+
+@pytest.fixture
+def service_credentials_not_available(service_credentials):
+
+    key_file = service_credentials['key_file']
+    client_email_file = service_credentials['client_file']
+
+    try:
+        _ = create_service_credentials(client_secret_file=client_email_file,
+                                       private_key=key_file)
+        should_fail = False
+    except IOError:
+        should_fail = True
+
+    return should_fail

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,5 @@
 
 import pytest
-
 from df2gspread.utils import (get_credentials,
                               create_service_credentials)
 
@@ -19,7 +18,7 @@ def user_credentials_not_available():
     try:
         _ = get_credentials()
         should_fail = False
-    except IOError:
+    except Exception:
         should_fail = True
 
     return should_fail
@@ -35,7 +34,7 @@ def service_credentials_not_available(service_credentials):
         _ = create_service_credentials(private_key_file=key_file,
                                        client_secret_file=client_email_file)
         should_fail = False
-    except IOError:
+    except Exception:
         should_fail = True
 
     return should_fail

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,8 +32,8 @@ def service_credentials_not_available(service_credentials):
     client_email_file = service_credentials['client_file']
 
     try:
-        _ = create_service_credentials(client_secret_file=client_email_file,
-                                       private_key=key_file)
+        _ = create_service_credentials(private_key_file=key_file,
+                                       client_secret_file=client_email_file)
         should_fail = False
     except IOError:
         should_fail = True

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -12,7 +12,6 @@ def test_client_secrets_credentials(service_credentials,
     key_file = service_credentials['key_file']
     client_file = service_credentials['client_file']
 
-    cred = create_service_credentials(private_key=key_file,
-                                      client_email=client_file)
+    cred = create_service_credentials(private_key_file=key_file, client_email=client_file)
 
     assert _is_valid_credentials(cred)

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -5,7 +5,8 @@ import pytest
 def test_client_secrets_credentials(service_credentials,
                                     service_credentials_not_available):
 
-    pytest.mark.xfail(condition=service_credentials_not_available, reason='Credentials')
+    if service_credentials_not_available:
+        pytest.mark.xfail(reason='Service Credentials Not Available')
 
     from df2gspread.utils import create_service_credentials, _is_valid_credentials
 

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -1,0 +1,18 @@
+
+import pytest
+
+
+def test_client_secrets_credentials(service_credentials,
+                                    service_credentials_not_available):
+
+    pytest.mark.xfail(condition=service_credentials_not_available, reason='Credentials')
+
+    from df2gspread.utils import create_service_credentials, _is_valid_credentials
+
+    key_file = service_credentials['key_file']
+    client_file = service_credentials['client_file']
+
+    cred = create_service_credentials(private_key=key_file,
+                                      client_email=client_file)
+
+    assert _is_valid_credentials(cred)

--- a/tests/test_df2gspread.py
+++ b/tests/test_df2gspread.py
@@ -17,8 +17,10 @@ def test_global_import():
     from df2gspread import df2gspread
 
 
-@pytest.mark.xfail(reason="Credentials")
-def test_spreadsheet():
+def test_spreadsheet(user_credentials_not_available):
+
+    pytest.mark.xfail(condition=user_credentials_not_available, reason='Credentials')
+
     import string
     import random
     import pandas as pd
@@ -50,8 +52,10 @@ def test_spreadsheet():
     delete_file(credentials, file_id)
 
 
-@pytest.mark.xfail(reason="Credentials")
-def test_worksheet():
+def test_worksheet(user_credentials_not_available):
+
+    pytest.mark.xfail(condition=user_credentials_not_available, reason='Credentials')
+
     import string
     import random
     import pandas as pd
@@ -82,6 +86,7 @@ def test_worksheet():
     credentials = get_credentials()
     file_id = get_file_id(credentials, filepath)
     delete_file(credentials, file_id)
+
 
 if __name__ == "__main__":
     test_worksheet()

--- a/tests/test_df2gspread.py
+++ b/tests/test_df2gspread.py
@@ -54,7 +54,8 @@ def test_spreadsheet(user_credentials_not_available):
 
 def test_worksheet(user_credentials_not_available):
 
-    pytest.mark.xfail(condition=user_credentials_not_available, reason='Credentials')
+    if user_credentials_not_available:
+        pytest.mark.xfail(reason='Credentials')
 
     import string
     import random


### PR DESCRIPTION
- Add support for direct input of credentials object to the functions.
- Add support for service client credentials.
- Add tests and fix tests so they only test pytest they should fail if they actually should fail.

resolves #8 