### PR TITLE
Fix bug for using pre-created credentials.

### DIFF
--- a/df2gspread/utils.py
+++ b/df2gspread/utils.py
@@ -52,7 +52,7 @@ def run(cmd):
     return output, errors
 
 
-def get_credentials(client_secret_file=CLIENT_SECRET_FILE, credentials=None):
+def get_credentials(credentials=None, client_secret_file=CLIENT_SECRET_FILE):
     """Consistently returns valid credentials object.
 
     See Also:
@@ -126,9 +126,11 @@ def create_service_credentials(private_key_file=None, client_email=None,
     if private_key_file is not None:
         with open(os.path.expanduser(private_key_file)) as f:
             private_key = f.read()
+    else:
+        private_key = None
 
     if client_email is None:
-        with open(client_secret_file) as client_file:
+        with open(os.path.expanduser(client_secret_file)) as client_file:
             client_data = json.load(client_file)
 
             if 'installed' in client_data:

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,12 @@
+# Running Tests
+
+See conftest.py, which sets up some shared data for the tests. The credentials
+testing is configured to look for specific files and if those do not exist, then
+the test that relies on those credentials will be marked to be expected to fail.
+
+Make sure that if the following files do exist, that the test is not marked to fail
+as that suggests that there are issues loading the files in general.
+
+
+- "Old" style of service credentials: `'~/.df2gspread_secrets.p12'`
+- "New" json style: `'~/.gdrive_service_private'`


### PR DESCRIPTION
- reorder the inputs to get credentials so positional call works correctly
- make sure that private_key exists before it is referenced
- support user path reference to client secret file
- add readme to explain tests