### PR TITLE
creates .oauth directory automatically if not present

### DIFF
--- a/df2gspread/utils.py
+++ b/df2gspread/utils.py
@@ -81,7 +81,10 @@ def get_credentials(credentials=None, client_secret_file=CLIENT_SECRET_FILE):
         flags = None
         logr.error(
             'Unable to parse oauth2client args; `pip install argparse`')
-
+    
+    token_folder = os.path.split(DEFAULT_TOKEN)[0]
+    if not os.path.exists(token_folder):
+        os.makedirs(token_folder)
     store = file.Storage(DEFAULT_TOKEN)
 
     credentials = store.get()


### PR DESCRIPTION
I ran into this bug while installing df2gspread on my Mac; you can reproduce by deleting your .oauth directory and running the code. It's a quick fix.