### PR TITLE
Remove redundant line, warn user if invalid credentials, add convert_to_oauth_credentials function

### DIFF
--- a/df2gspread/utils.py
+++ b/df2gspread/utils.py
@@ -67,9 +67,12 @@ def get_credentials(credentials=None, client_secret_file=CLIENT_SECRET_FILE):
     """
 
     # if the utility was provided credentials just return those
-    if _is_valid_credentials(credentials):
-        # auth for gspread
-        return credentials
+    if credentials:
+        if _is_valid_credentials(credentials):
+            # auth for gspread
+            return credentials
+        else:
+            print("Invalid credentials supplied. Will generate from default token.")
 
     try:
         import argparse

--- a/df2gspread/utils.py
+++ b/df2gspread/utils.py
@@ -48,6 +48,13 @@ def run(cmd):
         sys.exit(process.returncode)
     return output, errors
 
+def convert_to_oauth_credentials(token_file=None):
+    """Convert the specified token file into an oauth object that can be passed
+    directly as the credentials parameter to the upload or download functions.
+    """
+    token = os.path.expanduser(token_file)
+    store = file.Storage(token)
+    return store.get()
 
 def get_credentials(credentials=None, client_secret_file=CLIENT_SECRET_FILE):
     """Consistently returns valid credentials object.

--- a/df2gspread/utils.py
+++ b/df2gspread/utils.py
@@ -30,8 +30,6 @@ SCOPES = ('https://www.googleapis.com/auth/drive.metadata.readonly '
           'https://spreadsheets.google.com/feeds '
           'https://docs.google.com/feeds')
 
-DEFAULT_TOKEN = os.path.expanduser('~/.oauth/drive.json')
-
 
 def run(cmd):
     cmd = cmd if isinstance(cmd, list) else cmd.split()

--- a/df2gspread/utils.py
+++ b/df2gspread/utils.py
@@ -48,15 +48,7 @@ def run(cmd):
         sys.exit(process.returncode)
     return output, errors
 
-def convert_to_oauth_credentials(token_file=None):
-    """Convert the specified token file into an oauth object that can be passed
-    directly as the credentials parameter to the upload or download functions.
-    """
-    token = os.path.expanduser(token_file)
-    store = file.Storage(token)
-    return store.get()
-
-def get_credentials(credentials=None, client_secret_file=CLIENT_SECRET_FILE):
+def get_credentials(credentials=None, client_secret_file=CLIENT_SECRET_FILE, refresh_token=None):
     """Consistently returns valid credentials object.
 
     See Also:
@@ -64,6 +56,8 @@ def get_credentials(credentials=None, client_secret_file=CLIENT_SECRET_FILE):
 
     Args:
         client_secret_file (str): path to client secrets file, defaults to .gdrive_private
+        refresh_token (str): path to a user provided refresh token that is already 
+            pre-authenticated
         credentials (`~oauth2client.client.OAuth2Credentials`, optional): handle direct
             input of credentials, which will check credentials for valid type and
             return them
@@ -71,7 +65,7 @@ def get_credentials(credentials=None, client_secret_file=CLIENT_SECRET_FILE):
     Returns:
         `~oauth2client.client.OAuth2Credentials`: google credentials object
 
-    """
+    """      
 
     # if the utility was provided credentials just return those
     if credentials:
@@ -90,10 +84,13 @@ def get_credentials(credentials=None, client_secret_file=CLIENT_SECRET_FILE):
         logr.error(
             'Unable to parse oauth2client args; `pip install argparse`')
     
-    token_folder = os.path.split(DEFAULT_TOKEN)[0]
-    if not os.path.exists(token_folder):
-        os.makedirs(token_folder)
-    store = file.Storage(DEFAULT_TOKEN)
+    if refresh_token:
+        store = file.Storage(os.path.expanduser(refresh_token))
+    else:
+        token_folder = os.path.split(DEFAULT_TOKEN)[0]
+        if not os.path.exists(token_folder):
+            os.makedirs(token_folder)
+        store = file.Storage(DEFAULT_TOKEN)
 
     credentials = store.get()
     if not credentials or credentials.invalid:


### PR DESCRIPTION
This PR does 3 things: 

1. Removes a redundant line in utils.py 
2. Prints a warning to console to the user if they supply credentials and they are invalid. This is important because at the moment, if a user supplies credentials (say a collective team account's creds) and it happens to be invalid, it silently loads from `~/.oauth/drive.json`, which may have unintended consequences and/or give the user the false impression that the supplied credentials are working.
3. Adds a helper function that converts a user-supplied token file to an oauth object which can be passed directly to the `upload` or `download` functions as the `credentials` param.

To test the new helper function:
Checkout branch and from the `df2gspread/` folder (the one with `/bin`, `/docs`, etc), in python shell:

```
from df2gspread import df2gspread as d2g
from df2gspread import utils as utils
import pandas as pd
import numpy as np
# Copy the default token to an arbitrary location if you have one. Otherwise, skip
# and change the path in the convert_to_oauth_credentials() line to wherever the file is.
cp ~/.oauth/drive.json /tmp/drive.json
credentials = utils.convert_to_oauth_credentials('/tmp/drive.json')

df = pd.DataFrame(data = np.array([np.arange(100)]*1).T)
#Change to your spreadsheet
spreadsheet = '1EfKM7Yw56...'
wks_name = 'New Sheet123'
d2g.upload(df, spreadsheet, wks_name, credentials=credentials)
```
Should upload successfully even if you delete or don't have `~/.oauth/drive.json`. Can confirm by repeating the above after renaming or deleting `~/.oauth/drive.json`.

Now change the last line to gibberish like:
```
d2g.upload(df, spreadsheet, wks_name, credentials='fjashfads')
```

If you do this in master, if you have a valid `~/.oauth/drive.json`, it'll still upload with no warning message. In this branch, it'll now print to screen before successfully uploading using `~/.oauth/drive.json`:

```
>>> d2g.upload(df, spreadsheet, wks_name, credentials='fjashfads')
Invalid credentials supplied. Will generate from default token.
```
