### PR TITLE
Upgrade gspread version in requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ __irequires__ = [
     # CORE DEPENDENCIES
     'argparse>=1.3.0',
     'google-api-python-client==1.4.2',
-    'gspread==0.2.5',
+    'gspread==0.4.1',
     'oauth2client>=1.4.12',
     'pandas',
     'pycrypto'


### PR DESCRIPTION
df2gspread currently requires `'gspread==0.2.5'` in `setup.py`. However, there are various bugs in that version which have been corrected in newer versions, including the failure to print HTTP errors like the following if you have more than 2,000,000 cells in your workbook. Currently, with `0.2.5`, if you have 2,000,000 rows in your workbook and try to add more, you get the following:

```
>>> d2g.upload(df, spreadsheet, wks_name, credentials=credentials)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "df2gspread/df2gspread.py", line 72, in upload
    wks = get_worksheet(gc, gfile_id, wks_name, write_access=True)
  File "df2gspread/gfiles.py", line 80, in get_worksheet
    wks = spsh.add_worksheet(wks_name, 1000, 100)
  File "/Library/Python/2.7/site-packages/gspread/models.py", line 89, in add_worksheet
    elem = self.client.post_feed(url, ElementTree.tostring(feed))
  File "/Library/Python/2.7/site-packages/gspread/client.py", line 297, in post_feed
    message = ex.read().decode()
AttributeError: 'HTTPError' object has no attribute 'read'
```

This was a bug in the way gspread read the HTTP error and you never got the actual HTTP error. It has now been corrected, and in `0.4.1` you get this much clearer error message:

```
>>> d2g.upload(df, spreadsheet, wks_name, row_names = False, credentials=credentials)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "df2gspread/df2gspread.py", line 72, in upload
    wks = get_worksheet(gc, gfile_id, wks_name, write_access=True)
  File "df2gspread/gfiles.py", line 80, in get_worksheet
    wks = spsh.add_worksheet(wks_name, 1000, 100)
  File "/Library/Python/2.7/site-packages/gspread/models.py", line 89, in add_worksheet
    elem = self.client.post_feed(url, ElementTree.tostring(feed))
  File "/Library/Python/2.7/site-packages/gspread/client.py", line 228, in post_feed
    raise RequestError(ex.message)
gspread.exceptions.RequestError: 400: This action would increase the number of cells in the workbook above the limit of 2000000 cells.
```

Confirmed that switching to newer version does not affect uploading or downloading.