### PR TITLE
Better default worksheet size

### DIFF
--- a/df2gspread/df2gspread.py
+++ b/df2gspread/df2gspread.py
@@ -59,7 +59,7 @@ def upload(df, gfile="/New Spreadsheet", wks_name=None, chunk_size=1000,
         :type credentials: class 'oauth2client.client.OAuth2Credentials'
         :type start_cell: str
         :type df_size: bool
-        :type df_size: tuple
+        :type new_sheet_dimensions: tuple
         :returns: gspread Worksheet
         :rtype: class 'gspread.models.Worksheet'
 
@@ -90,8 +90,6 @@ def upload(df, gfile="/New Spreadsheet", wks_name=None, chunk_size=1000,
     # then for new sheets set it to new_sheet_dimensions, which is by default 1000x100
     if df_size:
         new_sheet_dimensions = (len(df), len(df.columns))
-    else:
-        new_sheet_dimensions = new_sheet_dimensions
 
     wks = get_worksheet(gc, gfile_id, wks_name, write_access=True, 
         new_sheet_dimensions=new_sheet_dimensions)
@@ -116,14 +114,12 @@ def upload(df, gfile="/New Spreadsheet", wks_name=None, chunk_size=1000,
     # resize larger or smaller to better match new size of pandas dataframe.
     # Otherwise, leave it the same size unless the sheet needs to be expanded
     # to accomodate a larger dataframe.
-    extra_col = 1 if col_names else 0
-    extra_row = 1 if row_names else 0
     if df_size:
-        wks.resize(rows=len(df.index) + extra_row, cols=len(df.columns) + extra_col)
-    if len(df.index) + extra_row + last_idx_adjust > wks.row_count:
-        wks.add_rows(len(df.index) - wks.row_count + extra_row + last_idx_adjust)
-    if len(df.columns) + extra_col + last_col_adjust  > wks.col_count:
-        wks.add_cols(len(df.columns) - wks.col_count + extra_col + last_col_adjust )
+        wks.resize(rows=len(df.index) + row_names, cols=len(df.columns) + col_names)
+    if len(df.index) + row_names + last_idx_adjust > wks.row_count:
+        wks.add_rows(len(df.index) - wks.row_count + row_names + last_idx_adjust)
+    if len(df.columns) + col_names + last_col_adjust  > wks.col_count:
+        wks.add_cols(len(df.columns) - wks.col_count + col_names + last_col_adjust )
 
     # Define first cell for rows and columns
     first_col = re.split('(\d+)',(wks.get_addr_int(1, start_col_int + 1)))[0].upper() if row_names else start_col

--- a/df2gspread/df2gspread.py
+++ b/df2gspread/df2gspread.py
@@ -23,7 +23,8 @@ except NameError:  # Python 3
 
 
 def upload(df, gfile="/New Spreadsheet", wks_name=None, chunk_size=1000,
-           col_names=True, row_names=True, clean=True, credentials=None):
+           col_names=True, row_names=True, clean=True, credentials=None,
+           df_size = False, new_sheet_dimensions = (1000,100)):
     '''
         Upload given Pandas DataFrame to Google Drive and returns 
         gspread Worksheet object
@@ -36,6 +37,16 @@ def upload(df, gfile="/New Spreadsheet", wks_name=None, chunk_size=1000,
         :param row_names: assing left column to row names for Pandas DataFrame
         :param clean: clean all data in worksheet before uploading 
         :param credentials: provide own credentials
+        :param df_size: 
+            -If True and worksheet name does NOT exist, will create 
+            a new worksheet that is the size of the df; otherwise, by default, 
+            creates sheet of 1000x100 cells. 
+            -If True and worksheet does exist, will resize larger or smaller to 
+            fit new dataframe. 
+            -If False and dataframe is larger than existing sheet, will resize 
+            the sheet larger.
+            -If False and dataframe is smaller than existing sheet, does not resize.
+        :param new_sheet_dimensions: tuple of (row, cols) for size of a new sheet
         :type df: class 'pandas.core.frame.DataFrame'
         :type gfile: str
         :type wks_name: str
@@ -44,6 +55,8 @@ def upload(df, gfile="/New Spreadsheet", wks_name=None, chunk_size=1000,
         :type row_names: bool
         :type clean: bool
         :type credentials: class 'oauth2client.client.OAuth2Credentials'
+        :type df_size: bool
+        :type df_size: tuple
         :returns: gspread Worksheet
         :rtype: class 'gspread.models.Worksheet'
 
@@ -69,7 +82,16 @@ def upload(df, gfile="/New Spreadsheet", wks_name=None, chunk_size=1000,
         # else look for file_id in drive
         gfile_id = get_file_id(credentials, gfile, write_access=True)
 
-    wks = get_worksheet(gc, gfile_id, wks_name, write_access=True)
+    # Tuple of rows, cols in the dataframe.
+    # If user did not explicitly specify to resize sheet to dataframe size
+    # then for new sheets set it to new_sheet_dimensions, which is by default 1000x100
+    if df_size:
+        new_sheet_dimensions = (len(df), len(df.columns))
+    else:
+        new_sheet_dimensions = new_sheet_dimensions
+
+    wks = get_worksheet(gc, gfile_id, wks_name, write_access=True, 
+        new_sheet_dimensions=new_sheet_dimensions)
     if clean:
         wks = clean_worksheet(wks, gfile_id, wks_name, credentials)
 
@@ -82,12 +104,18 @@ def upload(df, gfile="/New Spreadsheet", wks_name=None, chunk_size=1000,
         last_col = ascii_uppercase[seq_num % len(ascii_uppercase)] + last_col
         seq_num = seq_num // len(ascii_uppercase) - 1
 
-    # if pandas df large then given worksheet then increes num of cols or rows
-    if len(df.index) + 1 > wks.row_count:
-        wks.add_rows(len(df.index) - wks.row_count + 1)
-
-    if len(df.columns) + 1 > wks.col_count:
-        wks.add_cols(len(df.columns) - wks.col_count + 1)
+    # If user requested to resize sheet to fit dataframe, go ahead and 
+    # resize larger or smaller to better match new size of pandas dataframe.
+    # Otherwise, leave it the same size unless the sheet needs to be expanded
+    # to accomodate a larger dataframe.
+    extra_col = 1 if col_names else 0
+    extra_row = 1 if row_names else 0
+    if df_size:
+        wks.resize(rows=len(df.index) + extra_row, cols=len(df.columns) + extra_col)
+    if len(df.index) + extra_row > wks.row_count:
+        wks.add_rows(len(df.index) - wks.row_count + extra_row)
+    if len(df.columns) + extra_col > wks.col_count:
+        wks.add_cols(len(df.columns) - wks.col_count + extra_col)
 
     # Define first cell for rows and columns
     first_col = 'B1' if row_names else 'A1'

--- a/df2gspread/gfiles.py
+++ b/df2gspread/gfiles.py
@@ -77,8 +77,8 @@ def get_worksheet(gc, gfile_id, wks_name, write_access=False, new_sheet_dimensio
             wks = spsh.worksheet(wks_name)
         else:
             if write_access == True:
-                rows, cols = new_sheet_dimensions
-                wks = spsh.add_worksheet(wks_name, rows, cols)
+                #rows, cols = new_sheet_dimensions
+                wks = spsh.add_worksheet(wks_name, *new_sheet_dimensions)
             else:
                 wks = None
     except gspread.httpsession.HTTPError as e:

--- a/df2gspread/gfiles.py
+++ b/df2gspread/gfiles.py
@@ -61,7 +61,7 @@ def get_file_id(credentials, gfile, write_access=False):
     return file_id
 
 
-def get_worksheet(gc, gfile_id, wks_name, write_access=False):
+def get_worksheet(gc, gfile_id, wks_name, write_access=False, new_sheet_dimensions=(1000,100)):
     """DOCS..."""
     if wks_name is not None:
         wsheet_match = lambda wks: re.match(
@@ -77,7 +77,8 @@ def get_worksheet(gc, gfile_id, wks_name, write_access=False):
             wks = spsh.worksheet(wks_name)
         else:
             if write_access == True:
-                wks = spsh.add_worksheet(wks_name, 1000, 100)
+                rows, cols = new_sheet_dimensions
+                wks = spsh.add_worksheet(wks_name, rows, cols)
             else:
                 wks = None
     except gspread.httpsession.HTTPError as e:

--- a/tests/test_df2gspread.py
+++ b/tests/test_df2gspread.py
@@ -310,6 +310,129 @@ def test_df2gspread_start_cell(user_credentials_not_available):
     file_id = get_file_id(credentials, filepath)
     delete_file(credentials, file_id)
 
+def test_df2gspread_df_size(user_credentials_not_available):
+    if user_credentials_not_available:
+        pytest.xfail(reason='Credentials')
+
+    import string
+    import random
+    import numpy as np
+    import pandas as pd
+    import gspread
+    from pandas.util.testing import assert_frame_equal, assert_equal
+
+    from df2gspread import df2gspread as d2g
+    from df2gspread import gspread2df as g2d
+    from df2gspread.utils import get_credentials
+    from df2gspread.gfiles import get_file_id, delete_file, get_worksheet
+
+    filepath = '/df2gspread_tests/' + ''.join(
+        random.choice(string.ascii_uppercase + string.digits)
+        for _ in range(10))
+    credentials = get_credentials()
+    gc = gspread.authorize(credentials)
+    gfile_id = get_file_id(credentials, filepath, write_access=True)
+
+    df_upload_a = pd.DataFrame(
+        {0: ['1', '2', 'x', '4']},
+        index=[0, 1, 2, 3])
+
+    df_upload_b = pd.DataFrame(data = np.array([np.arange(1500)]*2).T).applymap(str)
+
+    #Uploading a small DF to new sheet to test for sizing down from default
+    d2g.upload(df_upload_a, filepath, "test1", row_names=False, col_names=False, df_size=True)
+    df_download = g2d.download(filepath, "test1")
+    df_upload = df_upload_a
+    wks = get_worksheet(gc, gfile_id, "test1")
+    assert_equal(wks.row_count, len(df_upload))
+    assert_equal(len(df_upload.columns), wks.col_count)
+    assert_equal(len(df_download), len(df_upload))
+    assert_frame_equal(df_upload, df_download)
+
+    #Upload a large DF to existing, smaller sheet to test for proper expansion
+    d2g.upload(df_upload_b, filepath, "test1", row_names=False, col_names=False, df_size=True)
+    df_download = g2d.download(filepath, "test1")
+    df_upload = df_upload_b
+    wks = get_worksheet(gc, gfile_id, "test1")
+    assert_equal(wks.row_count, len(df_upload))
+    assert_equal(len(df_upload.columns), wks.col_count)
+    assert_equal(len(df_download), len(df_upload))
+    assert_frame_equal(df_upload, df_download)
+
+    #Uploading a small DF to existing large sheet to test for sizing down from default
+    d2g.upload(df_upload_a, filepath, "test1", row_names=False, col_names=False, df_size=True)
+    df_download = g2d.download(filepath, "test1")
+    df_upload = df_upload_a
+    wks = get_worksheet(gc, gfile_id, "test1")
+    assert_equal(wks.row_count, len(df_upload))
+    assert_equal(len(df_upload.columns), wks.col_count)
+    assert_equal(len(df_download), len(df_upload))
+    assert_frame_equal(df_upload, df_download)
+
+    #New sheet with col names, make sure 1 extra row and column
+    d2g.upload(df_upload_a, filepath, "test2", row_names=True, col_names=True, df_size=True)
+    df_download = g2d.download(filepath, "test2")
+    df_upload = df_upload_a
+    wks = get_worksheet(gc, gfile_id, "test2")
+    assert_equal(wks.row_count, len(df_upload) + 1)
+    assert_equal(len(df_upload.columns) + 1, wks.col_count)
+    assert_equal(len(df_download), len(df_upload) + 1)
+
+    #Upload to new sheet with specified dimensions
+    d2g.upload(df_upload_a, filepath, "test3", row_names=False, col_names=False, new_sheet_dimensions=(100,10))
+    df_download = g2d.download(filepath, "test3")
+    df_upload = df_upload_a
+    wks = get_worksheet(gc, gfile_id, "test3")
+    assert_equal(wks.row_count, 100)
+    assert_equal(10, wks.col_count)
+    assert_frame_equal(df_upload, df_download)
+
+    #Test df_size with start_cell
+    d2g.upload(df_upload_a, filepath, "test4", row_names=False, col_names=False, start_cell='AB10', 
+        df_size = True)
+    df_download = g2d.download(filepath, "test4")
+    df_upload = df_upload_a
+    new_cols = 27
+    new_cols_array = np.chararray((len(df_upload), new_cols))
+    new_cols_array[:] = ''
+    df_new_cols = pd.DataFrame(data = new_cols_array)
+    df_upload = pd.concat([df_new_cols, df_upload], axis=1)
+    df_upload.columns = range(0, len(df_upload.columns))
+    new_rows = 9
+    new_rows_array = np.chararray((new_rows, len(df_upload.columns)))
+    new_rows_array[:] = ''
+    df_new_rows = pd.DataFrame(data = new_rows_array)
+    df_upload = df_new_rows.append(df_upload, ignore_index=True)
+    wks = get_worksheet(gc, gfile_id, "test4")
+    assert_equal(wks.row_count, len(df_upload))
+    assert_equal(len(df_upload.columns), wks.col_count)
+    assert_equal(len(df_download), len(df_upload))
+    assert_frame_equal(df_upload, df_download)
+
+    #Test df_size with start_cell and sheet dimensions which need to be expanded
+    d2g.upload(df_upload_a, filepath, "test5", row_names=False, col_names=False, start_cell='AB10', 
+        df_size = True, new_sheet_dimensions = (10,27))
+    df_download = g2d.download(filepath, "test5")
+    df_upload = df_upload_a
+    new_cols = 27
+    new_cols_array = np.chararray((len(df_upload), new_cols))
+    new_cols_array[:] = ''
+    df_new_cols = pd.DataFrame(data = new_cols_array)
+    df_upload = pd.concat([df_new_cols, df_upload], axis=1)
+    df_upload.columns = range(0, len(df_upload.columns))
+    new_rows = 9
+    new_rows_array = np.chararray((new_rows, len(df_upload.columns)))
+    new_rows_array[:] = ''
+    df_new_rows = pd.DataFrame(data = new_rows_array)
+    df_upload = df_new_rows.append(df_upload, ignore_index=True)
+    wks = get_worksheet(gc, gfile_id, "test5")
+    assert_equal(wks.row_count, len(df_upload))
+    assert_equal(len(df_upload.columns), wks.col_count)
+    assert_equal(len(df_download), len(df_upload))
+    assert_frame_equal(df_upload, df_download)
+
+    # Clear created file from drive
+    delete_file(credentials, gfile_id)
 
 def test_delete_file(user_credentials_not_available):
     if user_credentials_not_available:


### PR DESCRIPTION
This PR gives users the option to adjust the dimensions of worksheets to fit the dataframe.

You can now optionally pass in the param `df_size = True` to the upload() function in order to have it adjust the sheet to the size of your dataframe. This can affect both new sheets and existing sheets.

Currently, the default with a new sheet is to create one that is 1000 rows by 100 columns. This is an issue because you would by default only be able to create 20 worksheets since workbooks are capped at 2 million cells, and you would have to manually delete potentially unnecessary rows and columns in order to create more than 20 worksheets.

With this PR, if you try to upload the below, you will create a worksheet that is exactly 3 rows by 5 columns.:
```
df = [pd.Series([1., 2., 3.], index=['a', 'b', 'c']),
    pd.Series([1., 2., 3., 4.], index=['a', 'b', 'c', 'd'])]
d2g.upload(df, spreadsheet, wks_name, df_size = True)
```

Similarly, if you pass in `df_size = True` for an existing sheet, the sheet will automatically resize to match the dataframe's dimensions. This is possible using gspread's `resize()` function. Currently, `upload()` only allows for adding more rows and columns if the dataframe is bigger than the existing worksheet. This PR now allows for resizing the sheet smaller if the dataframe doesn't need all the space. This allows you to maximize the number of sheets you can create. 

If you do not pass `df_size` or pass `df_size = False`, the sheet size will not change unless the dataframe is larger, maintaining existing behavior. Thus, these changes will not affect any pre-existing jobs that use df2gspread since you must explicitly pass `df_size = True` to get the new behavior.

If you don't want to resize the sheet down to match the df's size but also want something different than the 1000x100 default, you can now also pass `new_sheet_dimensions = (num_rows, num_cols)` to `upload()` and this will override the default setting.

df_size should work with the pre-existing start_cell feature added in this PR (https://github.com/maybelinot/df2gspread/pull/17), but there may be possible edge cases where things break. I've added testing in this PR to check for continued proper behavior when these two are used together.

So to recap, for df_size: 
- If True and worksheet name does NOT exist, will create a new worksheet that is the size of the df.
- If False and the worksheet name does NOT exist, will create a default sheet of size 1000 x 100. If the dataframe ends up being larger, it will then resize only the dimension(s) that are larger up to fit the dataframe. It will not reduce pre-existing columns or rows.
- If True and worksheet does exist, will resize larger or smaller to fit new dataframe. 
- If False and dataframe is larger than existing sheet, will resize the sheet larger only on the dimension(s) that are larger. It will not reduce pre-existing columns or rows.
- If False and dataframe is smaller than existing sheet, does not resize.