### PR TITLE
Allow specifying start_cell on upload and refactor df2gspread using gspread addr methods

### DIFF
--- a/df2gspread/df2gspread.py
+++ b/df2gspread/df2gspread.py
@@ -79,51 +79,46 @@ def upload(df, gfile="/New Spreadsheet", wks_name=None, chunk_size=1000,
 
     start_col = re.split('(\d+)',start_cell)[0].upper()
     start_row = re.split('(\d+)',start_cell)[1]
+    start_row_int, start_col_int = wks.get_int_addr(start_cell)
 
     # find last index and column name (A B ... Z AA AB ... AZ BA)
-    last_idx = len(df.index) if col_names else len(df.index) - 1
-    last_idx_adjust = int(start_row) - 1
-    last_idx = last_idx + last_idx_adjust
+    num_rows = len(df.index) + 1 if col_names else len(df.index)
+    last_idx_adjust = start_row_int - 1
+    last_idx = num_rows + last_idx_adjust
 
-    seq_num = len(df.columns) if row_names else len(df.columns) - 1
-    seq_adjust = 0
-    for count, letter in enumerate(start_col):
-        seq_adjust = ord(letter.upper()) - 65 + (count*26) + seq_adjust
-    seq_num = seq_num + seq_adjust
-
-    last_col = ''
-    while seq_num >= 0:
-        last_col = ascii_uppercase[seq_num % len(ascii_uppercase)] + last_col
-        seq_num = seq_num // len(ascii_uppercase) - 1
+    num_cols = len(df.columns) + 1 if row_names else len(df.columns)
+    last_col_adjust = start_col_int - 1
+    last_col_int = num_cols + last_col_adjust
+    last_col = re.split('(\d+)',(wks.get_addr_int(1, last_col_int)))[0].upper()
 
     # if pandas df large than given worksheet then increase num of cols or rows
     if len(df.index) + 1 + last_idx_adjust > wks.row_count:
         wks.add_rows(len(df.index) - wks.row_count + 1 + last_idx_adjust)
 
-    if len(df.columns) + 1 + seq_adjust > wks.col_count:
-        wks.add_cols(len(df.columns) - wks.col_count + 1 + seq_adjust)
+    if len(df.columns) + 1 + last_col_adjust > wks.col_count:
+        wks.add_cols(len(df.columns) - wks.col_count + 1 + last_col_adjust)
 
     # Define first cell for rows and columns
-    first_col = start_col[:-1] + chr(ord(start_col[-1]) + 1) + start_row if row_names else start_col + start_row
-    first_row = start_col + str(int(start_row) + 1) if col_names else start_col + start_row
+    first_col = re.split('(\d+)',(wks.get_addr_int(1, start_col_int + 1)))[0].upper() if row_names else start_col
+    first_row = str(start_row_int + 1) if col_names else start_row
 
     # Addition of col names
     if col_names:
-        cell_list = wks.range('%s:%s%s' % (first_col, last_col, start_row))
+        cell_list = wks.range('%s%s:%s%s' % (first_col, start_row, last_col, start_row))
         for idx, cell in enumerate(cell_list):
             cell.value = df.columns.values[idx]
         wks.update_cells(cell_list)
 
     # Addition of row names
     if row_names:
-        cell_list = wks.range('%s:%s%d' % (first_row, start_col, last_idx + 1))
+        cell_list = wks.range('%s%s:%s%d' % (start_col, first_row, start_col, last_idx))
         for idx, cell in enumerate(cell_list):
             cell.value = df.index[idx]
         wks.update_cells(cell_list)
 
     # Addition of cell values
     cell_list = wks.range('%s%s:%s%d' % (
-        re.split('(\d+)',first_col)[0], re.split('(\d+)',first_row)[1], last_col, last_idx + 1))
+        first_col, first_row, last_col, last_idx))
     for j, idx in enumerate(df.index):
         for i, col in enumerate(df.columns.values):
             cell_list[i + j * len(df.columns.values)].value = df[col][idx]

--- a/df2gspread/df2gspread.py
+++ b/df2gspread/df2gspread.py
@@ -75,14 +75,16 @@ def upload(df, gfile="/New Spreadsheet", wks_name=None, chunk_size=1000,
         wks = clean_worksheet(wks, gfile_id, wks_name, credentials)
 
     start_col = start_cell[0].upper()
-    start_row = start_cell[1]
+    start_row = start_cell[1:]
 
     # find last index and column name (A B ... Z AA AB ... AZ BA)
     last_idx = len(df.index) if col_names else len(df.index) - 1
-    last_idx = last_idx + int(start_row) - 1
+    last_idx_adjust = int(start_row) - 1
+    last_idx = last_idx + last_idx_adjust
 
     seq_num = len(df.columns) if row_names else len(df.columns) - 1
-    seq_num = seq_num + ord(start_col.upper()) - 65
+    seq_adjust = ord(start_col.upper()) - 65
+    seq_num = seq_num + seq_adjust
 
     last_col = ''
     while seq_num >= 0:
@@ -90,11 +92,11 @@ def upload(df, gfile="/New Spreadsheet", wks_name=None, chunk_size=1000,
         seq_num = seq_num // len(ascii_uppercase) - 1
 
     # if pandas df large then given worksheet then increes num of cols or rows
-    if len(df.index) + 1 > wks.row_count:
-        wks.add_rows(len(df.index) - wks.row_count + 1)
+    if len(df.index) + 1 + last_idx_adjust > wks.row_count:
+        wks.add_rows(len(df.index) - wks.row_count + 1 + last_idx_adjust)
 
-    if len(df.columns) + 1 > wks.col_count:
-        wks.add_cols(len(df.columns) - wks.col_count + 1)
+    if len(df.columns) + 1 + seq_adjust > wks.col_count:
+        wks.add_cols(len(df.columns) - wks.col_count + 1 + seq_adjust)
 
     # Define first cell for rows and columns
     first_col = chr(ord(start_col) + 1) + start_row if row_names else start_col + start_row
@@ -116,7 +118,7 @@ def upload(df, gfile="/New Spreadsheet", wks_name=None, chunk_size=1000,
 
     # Addition of cell values
     cell_list = wks.range('%s%s:%s%d' % (
-        first_col[0], first_row[1], last_col, last_idx + 1))
+        first_col[0], first_row[1:], last_col, last_idx + 1))
     for j, idx in enumerate(df.index):
         for i, col in enumerate(df.columns.values):
             cell_list[i + j * len(df.columns.values)].value = df[col][idx]

--- a/df2gspread/df2gspread.py
+++ b/df2gspread/df2gspread.py
@@ -38,6 +38,7 @@ def upload(df, gfile="/New Spreadsheet", wks_name=None, chunk_size=1000,
         :param row_names: passing left column to row names for Pandas DataFrame
         :param clean: clean all data in worksheet before uploading 
         :param credentials: provide own credentials
+        :param start_cell: specify where to insert the DataFrame; default is A1
         :type df: class 'pandas.core.frame.DataFrame'
         :type gfile: str
         :type wks_name: str
@@ -46,6 +47,7 @@ def upload(df, gfile="/New Spreadsheet", wks_name=None, chunk_size=1000,
         :type row_names: bool
         :type clean: bool
         :type credentials: class 'oauth2client.client.OAuth2Credentials'
+        :type start_cell: str
         :returns: gspread Worksheet
         :rtype: class 'gspread.models.Worksheet'
 

--- a/df2gspread/df2gspread.py
+++ b/df2gspread/df2gspread.py
@@ -12,6 +12,7 @@ from itertools import islice
 
 import pandas as pd
 import gspread
+import re
 
 from .utils import get_credentials
 from .gfiles import get_file_id, get_worksheet
@@ -33,8 +34,8 @@ def upload(df, gfile="/New Spreadsheet", wks_name=None, chunk_size=1000,
         :param gfile: path to Google Spreadsheet or gspread ID
         :param wks_name: worksheet name
         :param chunk_size: size of chunk to upload
-        :param col_names: assing top row to column names for Pandas DataFrame
-        :param row_names: assing left column to row names for Pandas DataFrame
+        :param col_names: passing top row to column names for Pandas DataFrame
+        :param row_names: passing left column to row names for Pandas DataFrame
         :param clean: clean all data in worksheet before uploading 
         :param credentials: provide own credentials
         :type df: class 'pandas.core.frame.DataFrame'
@@ -74,8 +75,8 @@ def upload(df, gfile="/New Spreadsheet", wks_name=None, chunk_size=1000,
     if clean:
         wks = clean_worksheet(wks, gfile_id, wks_name, credentials)
 
-    start_col = start_cell[0].upper()
-    start_row = start_cell[1:]
+    start_col = re.split('(\d+)',start_cell)[0].upper()
+    start_row = re.split('(\d+)',start_cell)[1]
 
     # find last index and column name (A B ... Z AA AB ... AZ BA)
     last_idx = len(df.index) if col_names else len(df.index) - 1
@@ -83,7 +84,9 @@ def upload(df, gfile="/New Spreadsheet", wks_name=None, chunk_size=1000,
     last_idx = last_idx + last_idx_adjust
 
     seq_num = len(df.columns) if row_names else len(df.columns) - 1
-    seq_adjust = ord(start_col.upper()) - 65
+    seq_adjust = 0
+    for count, letter in enumerate(start_col):
+        seq_adjust = ord(letter.upper()) - 65 + (count*26) + seq_adjust
     seq_num = seq_num + seq_adjust
 
     last_col = ''
@@ -91,7 +94,7 @@ def upload(df, gfile="/New Spreadsheet", wks_name=None, chunk_size=1000,
         last_col = ascii_uppercase[seq_num % len(ascii_uppercase)] + last_col
         seq_num = seq_num // len(ascii_uppercase) - 1
 
-    # if pandas df large then given worksheet then increes num of cols or rows
+    # if pandas df large than given worksheet then increase num of cols or rows
     if len(df.index) + 1 + last_idx_adjust > wks.row_count:
         wks.add_rows(len(df.index) - wks.row_count + 1 + last_idx_adjust)
 
@@ -99,12 +102,12 @@ def upload(df, gfile="/New Spreadsheet", wks_name=None, chunk_size=1000,
         wks.add_cols(len(df.columns) - wks.col_count + 1 + seq_adjust)
 
     # Define first cell for rows and columns
-    first_col = chr(ord(start_col) + 1) + start_row if row_names else start_col + start_row
+    first_col = start_col[:-1] + chr(ord(start_col[-1]) + 1) + start_row if row_names else start_col + start_row
     first_row = start_col + str(int(start_row) + 1) if col_names else start_col + start_row
 
     # Addition of col names
     if col_names:
-        cell_list = wks.range('%s:%s%s' % (first_col, last_col,start_row))
+        cell_list = wks.range('%s:%s%s' % (first_col, last_col, start_row))
         for idx, cell in enumerate(cell_list):
             cell.value = df.columns.values[idx]
         wks.update_cells(cell_list)
@@ -118,7 +121,7 @@ def upload(df, gfile="/New Spreadsheet", wks_name=None, chunk_size=1000,
 
     # Addition of cell values
     cell_list = wks.range('%s%s:%s%d' % (
-        first_col[0], first_row[1:], last_col, last_idx + 1))
+        re.split('(\d+)',first_col)[0], re.split('(\d+)',first_row)[1], last_col, last_idx + 1))
     for j, idx in enumerate(df.index):
         for i, col in enumerate(df.columns.values):
             cell_list[i + j * len(df.columns.values)].value = df[col][idx]


### PR DESCRIPTION
This PR allows a user to override the default starting spot in the sheet to place the dataframe. The pre-existing behavior is to always put it starting at A1. This PR preserves this default setting, but now a user can pass in a `start_cell` parameter to insert the dataframe at a chosen location. It supports multi-char and multi-digit cells, so it can handle something like `start_cell = 'AF100'`. Furthermore, if there are not enough cells or if the location does not exist in the sheet, the sheet will add the necessary rows and/or cols to update it.

This PR will have merge conflicts with https://github.com/maybelinot/df2gspread/pull/16 and will have to be tweaked to deal with cases where a user requests a sheet sized to match the df as well as a starting spot, and since this is more of a nice to have feature as opposed to a more crucial one like https://github.com/maybelinot/df2gspread/pull/16 (at least in my case), I'd recommend reviewing that one first and I'll deal with the merge conflicts and updates in this PR after. But feel free to make comments about the general usability and implementation of this PR at any point. It works as is right now.

(Also made some minor tweaks to the comments, correcting some typos. And I refactored df2gspread so it uses gspread's native `get_addr_int` (e.g., AA = 27) and `get_int_addr` methods (vice versa) so you don't have to code your own custom solution: 
* https://gspread.readthedocs.io/en/latest/#gspread.Worksheet.get_addr_int
* https://gspread.readthedocs.io/en/latest/#gspread.Worksheet.get_int_addr

Hopefully this makes the code a bit cleaner and easier to expand on in the future.)