### PR TITLE
fix uploading header twice if DataFrame is empty, fixes #47

### DIFF
--- a/df2gspread/df2gspread.py
+++ b/df2gspread/df2gspread.py
@@ -68,6 +68,10 @@ def upload(df, gfile="/New Spreadsheet", wks_name=None,
             >>> wks.title
             'Example worksheet'
     '''
+    # check if dataframe is populated else raise error
+    if len(df) == 0:
+        raise EmptyDataFrameError('DataFrame is empty, nothing will be uploaded to Google Sheets.')
+    
     # access credentials
     credentials = get_credentials(credentials)
     # auth for gspread


### PR DESCRIPTION
returns an error if trying to upload an empty DataFrame to GSheets rather than adding two rows with the DataFrame header