### PR TITLE
Remove outdated argparse dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,6 @@ __desc__ = 'Export tables to Google Spreadsheets.'
 __scripts__ = ['bin/csv2gspread']
 __irequires__ = [
     # CORE DEPENDENCIES
-    'argparse>=1.3.0',
     'google-api-python-client>=1.6.7',
     'gspread>=2.1.1',
     'oauth2client>=1.5.0,<5.0.0dev',


### PR DESCRIPTION
The `argparse` library is included in Python 2.7 and in Python 3 since version 3.2, see https://pypi.org/project/argparse/.

The `argparse` PyPI library version isn't up-to-date anymore with the built-in version. It causes issues for apps that depend on `df2gspread` and that also use more recent capabilities of `argparse` since `df2gspread` overrides Python built-in version with an older version. See https://stackoverflow.com/questions/55619099/django-admin-typeerror-init-got-an-unexpected-keyword-argument-allow-abb