### PR TITLE
Update df2gspread.py

### DIFF
--- a/df2gspread/df2gspread.py
+++ b/df2gspread/df2gspread.py
@@ -71,10 +71,13 @@ def upload(df, gfile="/New Spreadsheet", wks_name=None,
             >>> wks.title
             'Example worksheet'
     '''
-    # access credentials
-    credentials = get_credentials(credentials)
-    # auth for gspread
-    gc = gspread.authorize(credentials)
+    
+    from google.colab import auth
+    auth.authenticate_user()
+
+    from google.auth import default
+    creds, _ = default()
+    gc = gspread.authorize(creds)
 
     try:
         gc.open_by_key(gfile).__repr__()


### PR DESCRIPTION
Hello, Working with this library I see that recent changes at the security authentication on google drive makes that the line 71-74 is deprecated then I modify this lines with and now I can write files using this new lines.

With the actual lines If I run the line 74 I get the next error -TypeError: Credentials need to be from either oauth2client or from google-auth.